### PR TITLE
take clientcert instances

### DIFF
--- a/httpc.go
+++ b/httpc.go
@@ -15,6 +15,8 @@ package httpc
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -154,6 +156,20 @@ func (r *Request) ClientCertificatesFromFiles(certFile, keyFile, caFile string) 
 	}
 
 	return r.ClientCertificates(clientCert, clientKey, caCert)
+}
+
+// ClientCertificatesFromInstance sets the client certificates from a cert instance
+func (r *Request) ClientCertificatesFromInstance(clientCertWithKey tls.Certificate, caChain []*x509.Certificate) (*Request, error) {
+	tlsConfig, err := setupClientCertificate(clientCertWithKey, caChain, r.client.Transport.(*http.Transport).TLSClientConfig)
+
+	if err != nil {
+		return r, err
+	}
+
+	r.client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
+
+	return r, nil
+
 }
 
 // QueryParams sets the query parameters for the client call

--- a/httpc.go
+++ b/httpc.go
@@ -75,7 +75,6 @@ type Request struct {
 
 // New instantiates a new http client
 func New(method, uri string) *Request {
-
 	// Instantiate a new NectIdent service using default options
 	return &Request{
 		method:                method,
@@ -136,7 +135,6 @@ func (r *Request) SkipCertificateVerification() *Request {
 
 // ClientCertificates sets client certificates from memory
 func (r *Request) ClientCertificates(clientCert, clientKey, caCert []byte) (*Request, error) {
-
 	tlsConfig, err := setupClientCertificateFromBytes(clientCert, clientKey, caCert, r.client.Transport.(*http.Transport).TLSClientConfig)
 	if err != nil {
 		return r, err
@@ -149,7 +147,6 @@ func (r *Request) ClientCertificates(clientCert, clientKey, caCert []byte) (*Req
 
 // ClientCertificatesFromFiles sets client certificates from files
 func (r *Request) ClientCertificatesFromFiles(certFile, keyFile, caFile string) (*Request, error) {
-
 	clientCert, clientKey, caCert, err := readClientCertificateFiles(certFile, keyFile, caFile)
 	if err != nil {
 		return r, err
@@ -169,7 +166,6 @@ func (r *Request) ClientCertificatesFromInstance(clientCertWithKey tls.Certifica
 	r.client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
 
 	return r, nil
-
 }
 
 // QueryParams sets the query parameters for the client call
@@ -292,7 +288,6 @@ func (r *Request) Run() error {
 
 // RunWithContext executes a request using a specific context
 func (r *Request) RunWithContext(ctx context.Context) error {
-
 	// Initialize new http.Request
 	req, err := http.NewRequestWithContext(ctx, r.method, r.uri, nil)
 	if err != nil {

--- a/tls.go
+++ b/tls.go
@@ -22,8 +22,12 @@ func setupClientCertificateFromBytes(clientCert, clientKey, caCert []byte, tlsCo
 		return nil, fmt.Errorf("failed to load client key / certificate: %s", err)
 	}
 
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+
 	// If required, instantiate CA certificate pool
-	if tlsConfig == nil || tlsConfig.RootCAs == nil {
+	if tlsConfig.RootCAs == nil {
 
 		caCertPool, err := x509.SystemCertPool()
 		if err != nil {
@@ -92,8 +96,12 @@ func setupClientCertificate(clientCertWithKey tls.Certificate, caChain []*x509.C
 		return nil, fmt.Errorf("no ca certificate(s) supplied")
 	}
 
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+
 	// If required, instantiate CA certificate pool
-	if tlsConfig == nil || tlsConfig.RootCAs == nil {
+	if tlsConfig.RootCAs == nil {
 
 		caCertPool, err := x509.SystemCertPool()
 		if err != nil {

--- a/tls.go
+++ b/tls.go
@@ -118,6 +118,8 @@ func setupClientCertificate(clientCertWithKey tls.Certificate, caChain []*x509.C
 	return tlsConfig, nil
 }
 
+const pemTypeCertificate = "CERTIFICATE"
+
 // ParseCAChain takes a file of PEM encoded things and returns the CERTIFICATEs in order
 // taken and adapted from crypto/tls
 func ParseCAChain(caCert []byte) ([]*x509.Certificate, error) {
@@ -128,12 +130,11 @@ func ParseCAChain(caCert []byte) ([]*x509.Certificate, error) {
 		if block == nil {
 			break
 		}
-		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+		if block.Type != pemTypeCertificate || len(block.Headers) != 0 {
 			continue
 		}
 
-		certBytes := block.Bytes
-		cert, err := x509.ParseCertificate(certBytes)
+		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			return nil, err
 		}

--- a/tls.go
+++ b/tls.go
@@ -15,7 +15,6 @@ var defaultTransport = http.DefaultTransport.(*http.Transport).Clone()
 // setupClientCertificateFromBytes reads the provided client certificate / key and CA certificate
 // from memory and creates / modifies a tls.Config object
 func setupClientCertificateFromBytes(clientCert, clientKey, caCert []byte, tlsConfig *tls.Config) (*tls.Config, error) {
-
 	// Load the key pair
 	clientKeyCert, err := tls.X509KeyPair(clientCert, clientKey)
 	if err != nil {
@@ -51,7 +50,6 @@ func setupClientCertificateFromBytes(clientCert, clientKey, caCert []byte, tlsCo
 // readClientCertificateFiles reads the provided client certificate / key and CA certificate
 // files
 func readClientCertificateFiles(certFile, keyFile, caFile string) ([]byte, []byte, []byte, error) {
-
 	// Read the client certificate / key file
 	clientCert, clientKey, err := readclientKeyCertificate(certFile, keyFile)
 	if err != nil {
@@ -70,7 +68,6 @@ func readClientCertificateFiles(certFile, keyFile, caFile string) ([]byte, []byt
 // readclientKeyCertificate reads both client certificate and key from their
 // respective files
 func readclientKeyCertificate(certFile, keyFile string) ([]byte, []byte, error) {
-
 	// Read the client certificate file
 	clientCert, err := ioutil.ReadFile(filepath.Clean(certFile))
 	if err != nil {

--- a/tls_test.go
+++ b/tls_test.go
@@ -5,15 +5,18 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"math"
 	"math/big"
+	"net"
 	"net/http"
 	"testing"
+	"time"
 )
 
-func constructTLSKeys() (tls.Certificate, []*x509.Certificate, error) {
-	fail := func(err error) (tls.Certificate, []*x509.Certificate, error) {
-		return tls.Certificate{}, nil, err
+func constructTLSKeys() (tls.Certificate, tls.Certificate, []*x509.Certificate, error) {
+	fail := func(err error) (tls.Certificate, tls.Certificate, []*x509.Certificate, error) {
+		return tls.Certificate{}, tls.Certificate{}, nil, err
 	}
 
 	// generate CA key
@@ -31,6 +34,12 @@ func constructTLSKeys() (tls.Certificate, []*x509.Certificate, error) {
 
 	caTemplate := &x509.Certificate{
 		SerialNumber: caSerial,
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
 	}
 
 	// generate CA cert
@@ -61,6 +70,10 @@ func constructTLSKeys() (tls.Certificate, []*x509.Certificate, error) {
 
 	leafTemplate := &x509.Certificate{
 		SerialNumber: leafSerial,
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
 
 	// generate leaf cert, signed by CA
@@ -70,24 +83,141 @@ func constructTLSKeys() (tls.Certificate, []*x509.Certificate, error) {
 		return fail(err)
 	}
 
+	// generate leaf key
+	serverKey, err := rsa.GenerateKey(rand.Reader, 1024)
+
+	if err != nil {
+		return fail(err)
+	}
+
+	serverSerial, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+
+	if err != nil {
+		return fail(err)
+	}
+
+	serverTemplate := &x509.Certificate{
+		SerialNumber: serverSerial,
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+
+		KeyUsage: x509.KeyUsageDigitalSignature,
+
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	// generate leaf cert, signed by CA
+	serverCert, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCertParsed, &serverKey.PublicKey, caKey)
+
+	if err != nil {
+		return fail(err)
+	}
+
 	tlsCert := tls.Certificate{
 		Certificate: [][]byte{leafCert},
 		PrivateKey:  leafKey,
 	}
+	serverTlsCert := tls.Certificate{
+		Certificate: [][]byte{serverCert},
+		PrivateKey:  serverKey,
+	}
 
-	return tlsCert, []*x509.Certificate{caCertParsed}, nil
+	return tlsCert, serverTlsCert, []*x509.Certificate{caCertParsed}, nil
+}
+
+func configureTLSServer(serverCertWithKey tls.Certificate, caChain []*x509.Certificate) (net.Listener, chan error, error) {
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, cert := range caChain {
+		caCertPool.AddCert(cert)
+
+	}
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{serverCertWithKey},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caCertPool,
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:10002", config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := make(chan error, 1)
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					return
+				}
+				c <- err
+				continue
+			}
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+			}
+			err = resp.Write(conn)
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					return
+				}
+				c <- err
+				continue
+			}
+			c <- nil
+		}
+	}()
+
+	return ln, c, nil
 }
 
 func TestCertificateInstance(t *testing.T) {
 	r := New(http.MethodGet, "/")
 
-	clientCertKey, caBytes, err := constructTLSKeys()
+	clientCertKey, serverTlsCert, caChain, err := constructTLSKeys()
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = r.ClientCertificatesFromInstance(clientCertKey, caBytes)
+	_, err = r.ClientCertificatesFromInstance(clientCertKey, caChain)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	ln, respChan, err := configureTLSServer(serverTlsCert, caChain)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer ln.Close()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Define request disabling certificate validation
+	req, err := New(http.MethodGet, "https://127.0.0.1:10002/").ClientCertificatesFromInstance(clientCertKey, caChain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = req.Run()
+	// Execute the request
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = <-respChan
 
 	if err != nil {
 		t.Error(err)
@@ -97,7 +227,7 @@ func TestCertificateInstance(t *testing.T) {
 func TestCertificateInstanceNoPrivateKey(t *testing.T) {
 	r := New(http.MethodGet, "/")
 
-	clientCertKey, caBytes, err := constructTLSKeys()
+	clientCertKey, _, caBytes, err := constructTLSKeys()
 
 	if err != nil {
 		t.Fatal(err)

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,113 @@
+package httpc
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"math"
+	"math/big"
+	"net/http"
+	"testing"
+)
+
+func constructTLSKeys() (tls.Certificate, []*x509.Certificate, error) {
+	fail := func(err error) (tls.Certificate, []*x509.Certificate, error) {
+		return tls.Certificate{}, nil, err
+	}
+
+	// generate CA key
+	caKey, err := rsa.GenerateKey(rand.Reader, 1024)
+
+	if err != nil {
+		return fail(err)
+	}
+
+	caSerial, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+
+	if err != nil {
+		return fail(err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber: caSerial,
+	}
+
+	// generate CA cert
+	caCert, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+
+	if err != nil {
+		return fail(err)
+	}
+
+	caCertParsed, err := x509.ParseCertificate(caCert)
+
+	if err != nil {
+		return fail(err)
+	}
+
+	// generate leaf key
+	leafKey, err := rsa.GenerateKey(rand.Reader, 1024)
+
+	if err != nil {
+		return fail(err)
+	}
+
+	leafSerial, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+
+	if err != nil {
+		return fail(err)
+	}
+
+	leafTemplate := &x509.Certificate{
+		SerialNumber: leafSerial,
+	}
+
+	// generate leaf cert, signed by CA
+	leafCert, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCertParsed, &leafKey.PublicKey, caKey)
+
+	if err != nil {
+		return fail(err)
+	}
+
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{leafCert},
+		PrivateKey:  leafKey,
+	}
+
+	return tlsCert, []*x509.Certificate{caCertParsed}, nil
+}
+
+func TestCertificateInstance(t *testing.T) {
+	r := New(http.MethodGet, "/")
+
+	clientCertKey, caBytes, err := constructTLSKeys()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = r.ClientCertificatesFromInstance(clientCertKey, caBytes)
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCertificateInstanceNoPrivateKey(t *testing.T) {
+	r := New(http.MethodGet, "/")
+
+	clientCertKey, caBytes, err := constructTLSKeys()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientCertKey.PrivateKey = nil
+
+	_, err = r.ClientCertificatesFromInstance(clientCertKey, caBytes)
+
+	if err == nil {
+		t.Error("expected err, got none")
+	}
+}


### PR DESCRIPTION
takes in client instances of certificate and chain. this allows the use of encrypted (aka password protected) private keys on the client certificate side. I did not touch the original code as I wasn't sure about the impact, this resulted in some duplicated code.