### PR TITLE
[feature] Add convenience methods for Bearer and generic token-based auth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,31 @@
+package httpc
+
+import "net/http"
+
+const authHeaderKey = "Authorization"
+
+// AuthBasic sets parameters to perform basic authentication
+func (r *Request) AuthBasic(user, password string) *Request {
+	r.httpAuthFunc = func(c *http.Request) {
+		c.SetBasicAuth(user, password)
+	}
+	return r
+}
+
+// AuthToken sets parameters to perform any token-based authentication, setting
+// "Authorization: <prefix> <token>"
+func (r *Request) AuthToken(prefix, token string) *Request {
+	r.httpAuthFunc = func(c *http.Request) {
+		c.Header.Set(authHeaderKey, prefix+" "+token)
+	}
+	return r
+}
+
+// AuthBearer sets parameters to perform bearer token authentication, setting
+// "Authorization: Bearer <token>"
+func (r *Request) AuthBearer(token string) *Request {
+	r.httpAuthFunc = func(c *http.Request) {
+		c.Header.Set(authHeaderKey, "Bearer "+token)
+	}
+	return r
+}

--- a/httpc.go
+++ b/httpc.go
@@ -209,14 +209,6 @@ func (r *Request) EncodeXML(v interface{}) *Request {
 	return r
 }
 
-// AuthBasic sets parameters to perform basic authentication
-func (r *Request) AuthBasic(user, password string) *Request {
-	r.httpAuthFunc = func(c *http.Request) {
-		c.SetBasicAuth(user, password)
-	}
-	return r
-}
-
 // ParseFn sets a generic parsing function for the result of the client call
 func (r *Request) ParseFn(parseFn func(resp *http.Response) error) *Request {
 	r.parseFn = parseFn

--- a/httpc_test.go
+++ b/httpc_test.go
@@ -556,6 +556,48 @@ func TestBasicAuth(t *testing.T) {
 	}
 }
 
+func TestBearerAuth(t *testing.T) {
+	uri := joinURI(httpsEndpoint, "authBearer")
+
+	token := "testtoken"
+
+	// Set up a mock matcher
+	g := gock.New(uri)
+	g.Persist()
+	g.Get(path.Base(uri)).
+		MatchHeader("Authorization", fmt.Sprintf("Bearer %s", token)).
+		Reply(http.StatusOK)
+
+	req := New(http.MethodGet, uri).AuthBearer(token)
+	gock.InterceptClient(req.client)
+	defer gock.RestoreClient(req.client)
+
+	if err := req.Run(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTokenAuth(t *testing.T) {
+	uri := joinURI(httpsEndpoint, "authToken")
+
+	prefix, token := "testprefix", "testtoken"
+
+	// Set up a mock matcher
+	g := gock.New(uri)
+	g.Persist()
+	g.Get(path.Base(uri)).
+		MatchHeader("Authorization", fmt.Sprintf("%s %s", prefix, token)).
+		Reply(http.StatusOK)
+
+	req := New(http.MethodGet, uri).AuthToken(prefix, token)
+	gock.InterceptClient(req.client)
+	defer gock.RestoreClient(req.client)
+
+	if err := req.Run(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestModifyRequest(t *testing.T) {
 	uri := joinURI(httpsEndpoint, "modifyRequest")
 


### PR DESCRIPTION
- Adds `AuthToken(prefix, token string)` to support generic token auth (e.g. non-standard Bearer auth or API key auth)
- Adds `AuthBearer(token string)` to support standard Bearer auth
- Minor refactor to group authentication methods
 
Closes #18 