### PR TITLE
[bugfix] Improve handling of retry / back-off options and enforce their consistent use

### DIFF
--- a/httpc_test.go
+++ b/httpc_test.go
@@ -128,6 +128,26 @@ func TestTimeout(t *testing.T) {
 	})
 }
 
+func TestRetryInvalidOptions(t *testing.T) {
+	uri := joinURI(httpsEndpoint, "invalidretries")
+	if err := New(http.MethodPut, uri).
+		RetryBackOffErrFn(func(r *http.Response, err error) bool { return true }).
+		Body([]byte(helloWorldString)).Run(); err == nil || err.Error() != "cannot use RetryBackOffErrFn() [used: true] / RetryEventFn() [used: false] without providing intervals via RetryBackOff()" {
+		t.Fatal(err)
+	}
+	if err := New(http.MethodPut, uri).
+		RetryEventFn(func(i int, r *http.Response, err error) {}).
+		Body([]byte(helloWorldString)).Run(); err == nil || err.Error() != "cannot use RetryBackOffErrFn() [used: false] / RetryEventFn() [used: true] without providing intervals via RetryBackOff()" {
+		t.Fatal(err)
+	}
+	if err := New(http.MethodPut, uri).
+		RetryBackOffErrFn(func(r *http.Response, err error) bool { return true }).
+		RetryEventFn(func(i int, r *http.Response, err error) {}).
+		Body([]byte(helloWorldString)).Run(); err == nil || err.Error() != "cannot use RetryBackOffErrFn() [used: true] / RetryEventFn() [used: true] without providing intervals via RetryBackOff()" {
+		t.Fatal(err)
+	}
+}
+
 func TestRetries(t *testing.T) {
 	uri := joinURI(httpsEndpoint, "retries")
 	intervals := Intervals{10 * time.Millisecond, 15 * time.Millisecond, 20 * time.Millisecond}


### PR DESCRIPTION
Issue was discovered by a user (thx to @els0r) who was using `RetryBackOffErrFn()` without specifying `RetryBackOff()`, which cause unexpected behavior (and most importantly: was accepted without handling).

@femaref I'm including you in this PR because it _might_ have an impact at Nect. If of course you're using the functionality as intended nothing changes, but should you have a situation where you're missing the `RetryBackOff()` while using `RetryBackOffErrFn()` or `RetryEventFn()` (the latter is unlikely because it was added just a few days ago) you might now (correctly) get an error. I'd appreciate if you could do a quick cross-check if that's the case :pray: 

Thanks a lot!