### PR TITLE
Remove obsolete references to io/ioutil and replace them

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fmt.Println(buf.String())
 
 #### Perform HTTPS GET request (with query parameters + headers + basic auth), validating request and response against OpenAPIv3 specification
 ```go
-openAPIFileData, err := ioutil.ReadFile("/tmp/openapi.json")
+openAPIFileData, err := os.ReadFile("/tmp/openapi.json")
 if err != nil {
 	log.Fatalf("Error opening OpenAPI specification file: %s", err)
 }

--- a/httpc_test.go
+++ b/httpc_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/gob"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -202,7 +202,7 @@ func TestRetries(t *testing.T) {
 	g.Persist()
 	g.Put(path.Base(uri)).AddMatcher(func(r1 *http.Request, r2 *gock.Request) (bool, error) {
 
-		bodyData, err := ioutil.ReadAll(r1.Body)
+		bodyData, err := io.ReadAll(r1.Body)
 		if err != nil {
 			return false, err
 		}
@@ -264,7 +264,7 @@ func TestRetriesErrorFn(t *testing.T) {
 	g := gock.New(uri)
 	g.Persist()
 	g.Put(path.Base(uri)).AddMatcher(func(r1 *http.Request, r2 *gock.Request) (bool, error) {
-		bodyData, err := ioutil.ReadAll(r1.Body)
+		bodyData, err := io.ReadAll(r1.Body)
 		if err != nil {
 			return false, err
 		}
@@ -400,7 +400,7 @@ func testJSONRequest(duplicateHeader bool, t *testing.T) {
 			return false, fmt.Errorf("unexpected content-type values: %s", contentTypeValues)
 		}
 
-		bodyBytes, err := ioutil.ReadAll(r1.Body)
+		bodyBytes, err := io.ReadAll(r1.Body)
 		if err != nil {
 			return false, err
 		}
@@ -483,7 +483,7 @@ func testYAMLRequest(duplicateHeader bool, t *testing.T) {
 			return false, fmt.Errorf("unexpected content-type values: %s", contentTypeValues)
 		}
 
-		bodyBytes, err := ioutil.ReadAll(r1.Body)
+		bodyBytes, err := io.ReadAll(r1.Body)
 		if err != nil {
 			return false, err
 		}
@@ -566,7 +566,7 @@ func testXMLRequest(duplicateHeader bool, t *testing.T) {
 			return false, fmt.Errorf("unexpected content-type values: %s", contentTypeValues)
 		}
 
-		bodyBytes, err := ioutil.ReadAll(r1.Body)
+		bodyBytes, err := io.ReadAll(r1.Body)
 		if err != nil {
 			return false, err
 		}
@@ -792,7 +792,7 @@ func TestClientDelay(t *testing.T) {
 	g := gock.New(uri)
 	g.Get(path.Base(uri)).
 		AddMatcher(gock.MatchFunc(func(arg1 *http.Request, arg2 *gock.Request) (bool, error) {
-			bodyBytes, err := ioutil.ReadAll(arg1.Body)
+			bodyBytes, err := io.ReadAll(arg1.Body)
 			if err != nil {
 				return false, err
 			}
@@ -1084,7 +1084,7 @@ func TestTable(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			responseBody:       []byte(helloWorldString),
 			responseFn: func(resp *http.Response) error {
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return err
 				}
@@ -1204,7 +1204,7 @@ func runGenericRequest(k *Request, v testCase) error {
 	// Handle request body
 	if v.requestBody != nil {
 		g.AddMatcher(gock.MatchFunc(func(arg1 *http.Request, arg2 *gock.Request) (bool, error) {
-			bodyBytes, err := ioutil.ReadAll(arg1.Body)
+			bodyBytes, err := io.ReadAll(arg1.Body)
 			if err != nil {
 				return false, err
 			}
@@ -1302,7 +1302,7 @@ func joinURI(base, suffix string) string {
 
 func genTempFile(data []byte) (string, error) {
 
-	tmpfile, err := ioutil.TempFile("", "httpc_test")
+	tmpfile, err := os.CreateTemp("", "httpc_test")
 	if err != nil {
 		return "", err
 	}

--- a/tls.go
+++ b/tls.go
@@ -5,8 +5,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 )
 
@@ -59,7 +59,7 @@ func readClientCertificateFiles(certFile, keyFile, caFile string) ([]byte, []byt
 	}
 
 	// Read CA certificate from file
-	caCert, err := ioutil.ReadFile(filepath.Clean(caFile))
+	caCert, err := os.ReadFile(filepath.Clean(caFile))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
@@ -71,13 +71,13 @@ func readClientCertificateFiles(certFile, keyFile, caFile string) ([]byte, []byt
 // respective files
 func readclientKeyCertificate(certFile, keyFile string) ([]byte, []byte, error) {
 	// Read the client certificate file
-	clientCert, err := ioutil.ReadFile(filepath.Clean(certFile))
+	clientCert, err := os.ReadFile(filepath.Clean(certFile))
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Read the client key file
-	clientKey, err := ioutil.ReadFile(filepath.Clean(keyFile))
+	clientKey, err := os.ReadFile(filepath.Clean(keyFile))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Will skip review / override branch restrictions since the calls are equivalent.

Closes #29