### PR TITLE
[bugfix] Fix redirect handling for 307 and 308 status codes

### DIFF
--- a/httpc.go
+++ b/httpc.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -298,11 +299,15 @@ func (r *Request) Run() error {
 	return r.RunWithContext(context.Background())
 }
 
+var (
+	errorEncodedRawBodyCollision = errors.New("cannot use both body encoding and raw body content")
+)
+
 func (r *Request) prepBody() (body io.ReadCloser, err error) {
 	// If requested, parse the requst body using the specified encoder
 	if r.bodyEncoder != nil {
 		if len(r.body) > 0 {
-			return body, fmt.Errorf("cannot use both body encoding and raw body content")
+			return body, errorEncodedRawBodyCollision
 		}
 
 		r.body, err = r.bodyEncoder.Encode()

--- a/httpc.go
+++ b/httpc.go
@@ -316,6 +316,10 @@ func (r *Request) prepBody() (body io.ReadCloser, err error) {
 		}
 	}
 
+	if len(r.body) == 0 {
+		return nil, nil
+	}
+
 	// If a delay was requested, assign a delayed reader
 	if r.delay > 0 {
 		return io.NopCloser(newDelayedReader(bytes.NewBuffer(r.body), r.delay)), nil

--- a/httpc.go
+++ b/httpc.go
@@ -298,13 +298,51 @@ func (r *Request) Run() error {
 	return r.RunWithContext(context.Background())
 }
 
+func (r *Request) prepBody() (body io.ReadCloser, err error) {
+	// If requested, parse the requst body using the specified encoder
+	if r.bodyEncoder != nil {
+		if len(r.body) > 0 {
+			return body, fmt.Errorf("cannot use both body encoding and raw body content")
+		}
+
+		r.body, err = r.bodyEncoder.Encode()
+		if err != nil {
+			return body, fmt.Errorf("error encoding body: %w", err)
+		}
+	}
+
+	// If a delay was requested, assign a delayed reader
+	if r.delay > 0 {
+		return io.NopCloser(newDelayedReader(bytes.NewBuffer(r.body), r.delay)), nil
+	}
+
+	return io.NopCloser(bytes.NewBuffer(r.body)), nil
+}
+
 // RunWithContext executes a request using a specific context
 func (r *Request) RunWithContext(ctx context.Context) error {
 
+	reqBody, err := r.prepBody()
+	if err != nil {
+		return fmt.Errorf("error preparing request body: %w", err)
+	}
+
 	// Initialize new http.Request
-	req, err := http.NewRequestWithContext(ctx, r.method, r.uri, nil)
+	//
+	// From net/http:
+	//
+	// 	If body is of type *bytes.Buffer, *bytes.Reader, or *strings.Reader, the returned request's ContentLength is set to its exact value
+	// 	(instead of -1), GetBody is populated (so 307 and 308 redirects can replay the body), and Body is set to NoBody if the ContentLength
+	// 	is 0.
+	//
+	// Hence, setting the reqBody via NewRequestWithContext will make sure that the internal handling of net/http sets the right parameters
+	// so redirect handling (amongst other things) is working properly
+	req, err := http.NewRequestWithContext(ctx, r.method, r.uri, reqBody)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
+	}
+	if r.bodyEncoder != nil {
+		req.Header.Set("Content-Type", r.bodyEncoder.ContentType())
 	}
 
 	// Notify the server that the connection should be closed after completion of
@@ -315,23 +353,6 @@ func (r *Request) RunWithContext(ctx context.Context) error {
 	if r.httpAuthFunc != nil {
 		r.httpAuthFunc(req)
 	}
-
-	// If requested, parse the requst body using the specified encoder
-	if r.bodyEncoder != nil {
-
-		if len(r.body) > 0 {
-			return fmt.Errorf("cannot use both body encoding and raw body content")
-		}
-
-		r.body, err = r.bodyEncoder.Encode()
-		if err != nil {
-			return fmt.Errorf("error encoding body: %w", err)
-		}
-		req.Header.Set("Content-Type", r.bodyEncoder.ContentType())
-	}
-
-	// If a body was provided, assign it to the request
-	r.setBody(req)
 
 	// If URL parameters were provided, assign them to the request
 	if r.queryParams != nil {

--- a/httpc_test.go
+++ b/httpc_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -76,7 +77,7 @@ func TestInvalidRequest(t *testing.T) {
 	if err := New("", "NOTVALID").Run(); err == nil || err.Error() != `Get "NOTVALID": unsupported protocol scheme ""` {
 		t.Fatalf("Unexpected success creating invalid request: %s", err)
 	}
-	if err := New(http.MethodGet, "").EncodeJSON(struct{}{}).Body([]byte{0}).Run(); err == nil || err.Error() != `cannot use both body encoding and raw body content` {
+	if err := New(http.MethodGet, "").EncodeJSON(struct{}{}).Body([]byte{0}).Run(); err == nil || !strings.Contains(err.Error(), errorEncodedRawBodyCollision.Error()) {
 		t.Fatalf("Unexpected success creating invalid request: %s", err)
 	}
 }

--- a/httpc_test.go
+++ b/httpc_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/gob"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -16,7 +17,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -77,7 +77,7 @@ func TestInvalidRequest(t *testing.T) {
 	if err := New("", "NOTVALID").Run(); err == nil || err.Error() != `Get "NOTVALID": unsupported protocol scheme ""` {
 		t.Fatalf("Unexpected success creating invalid request: %s", err)
 	}
-	if err := New(http.MethodGet, "").EncodeJSON(struct{}{}).Body([]byte{0}).Run(); err == nil || !strings.Contains(err.Error(), errorEncodedRawBodyCollision.Error()) {
+	if err := New(http.MethodGet, "").EncodeJSON(struct{}{}).Body([]byte{0}).Run(); err == nil || !errors.Is(err, errorEncodedRawBodyCollision) {
 		t.Fatalf("Unexpected success creating invalid request: %s", err)
 	}
 }


### PR DESCRIPTION
Set the `GetBody` function of a request explicitly when preparing the body. This makes sure that the client can follow redirects from 307 and 308 status codes without losing the original body.

Also, make sure that the `ContentLength` is set.

Closes #32 