### PR TITLE
[bugfix] Properly set request.GetBody for redirect handling

### DIFF
--- a/httpc.go
+++ b/httpc.go
@@ -335,6 +335,7 @@ func (r *Request) setBody(req *http.Request) (err error) {
 			dr := newDelayedReader(bytes.NewBuffer(bodyBytes), r.delay)
 
 			req.GetBody = func() (io.ReadCloser, error) {
+				fmt.Println("buf: called GetBody")
 				snapshot := *dr
 				return io.NopCloser(&snapshot), nil
 			}
@@ -346,6 +347,7 @@ func (r *Request) setBody(req *http.Request) (err error) {
 
 		req.GetBody = func() (io.ReadCloser, error) {
 			snapshot := *buf
+			fmt.Println("buf =", snapshot.String(), "; length =", snapshot.Len())
 			return io.NopCloser(&snapshot), nil
 		}
 		req.Body = io.NopCloser(buf)

--- a/httpc.go
+++ b/httpc.go
@@ -362,8 +362,7 @@ func (r *Request) RunWithContext(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
-	err = r.setBody(req)
-	if err != nil {
+	if err = r.setBody(req); err != nil {
 		return fmt.Errorf("failed to set request body: %w", err)
 	}
 
@@ -468,8 +467,7 @@ func (r *Request) RunWithContext(ctx context.Context) error {
 		case <-ticker.C:
 		}
 
-		err = r.setBody(req)
-		if err != nil {
+		if err = r.setBody(req); err != nil {
 			return fmt.Errorf("failed to set request body: %w", err)
 		}
 		resp, err = r.client.Do(req)

--- a/httpc.go
+++ b/httpc.go
@@ -335,7 +335,6 @@ func (r *Request) setBody(req *http.Request) (err error) {
 			dr := newDelayedReader(bytes.NewBuffer(bodyBytes), r.delay)
 
 			req.GetBody = func() (io.ReadCloser, error) {
-				fmt.Println("buf: called GetBody")
 				snapshot := *dr
 				return io.NopCloser(&snapshot), nil
 			}
@@ -347,7 +346,7 @@ func (r *Request) setBody(req *http.Request) (err error) {
 
 		req.GetBody = func() (io.ReadCloser, error) {
 			snapshot := *buf
-			fmt.Println("buf =", snapshot.String(), "; length =", snapshot.Len())
+			fmt.Println(time.Now(), "buf =", buf.String(), "; snapshot =", snapshot.String(), "; length =", snapshot.Len())
 			return io.NopCloser(&snapshot), nil
 		}
 		req.Body = io.NopCloser(buf)

--- a/httpc.go
+++ b/httpc.go
@@ -335,16 +335,14 @@ func (r *Request) setBody(req *http.Request) (err error) {
 			dr := newDelayedReader(bytes.NewBuffer(bodyBytes), r.delay)
 
 			req.GetBody = func() (io.ReadCloser, error) {
-				snapshot := newDelayedReader(bytes.NewBuffer(bodyBytes), r.delay)
+				snapshot := newDelayedReader(bytes.NewReader(bodyBytes), r.delay)
 				return io.NopCloser(snapshot), nil
 			}
 			req.Body = io.NopCloser(dr)
 			return nil
 		}
 
-		buf := bytes.NewBuffer(bodyBytes)
-
-		fmt.Println(time.Now(), "buf =", buf.String())
+		buf := bytes.NewReader(bodyBytes)
 
 		req.GetBody = func() (io.ReadCloser, error) {
 			return io.NopCloser(bytes.NewReader(bodyBytes)), nil

--- a/httpc.go
+++ b/httpc.go
@@ -335,8 +335,8 @@ func (r *Request) setBody(req *http.Request) (err error) {
 			dr := newDelayedReader(bytes.NewBuffer(bodyBytes), r.delay)
 
 			req.GetBody = func() (io.ReadCloser, error) {
-				snapshot := *dr
-				return io.NopCloser(&snapshot), nil
+				snapshot := newDelayedReader(bytes.NewBuffer(bodyBytes), r.delay)
+				return io.NopCloser(snapshot), nil
 			}
 			req.Body = io.NopCloser(dr)
 			return nil
@@ -344,10 +344,10 @@ func (r *Request) setBody(req *http.Request) (err error) {
 
 		buf := bytes.NewBuffer(bodyBytes)
 
+		fmt.Println(time.Now(), "buf =", buf.String())
+
 		req.GetBody = func() (io.ReadCloser, error) {
-			snapshot := *buf
-			fmt.Println(time.Now(), "buf =", buf.String(), "; snapshot =", snapshot.String(), "; length =", snapshot.Len())
-			return io.NopCloser(&snapshot), nil
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
 		}
 		req.Body = io.NopCloser(buf)
 	}

--- a/httpc.go
+++ b/httpc.go
@@ -303,60 +303,69 @@ var (
 	errorEncodedRawBodyCollision = errors.New("cannot use both body encoding and raw body content")
 )
 
-func (r *Request) prepBody() (body io.ReadCloser, err error) {
+func (r *Request) setBody(req *http.Request) (err error) {
 
 	// If requested, parse the requst body using the specified encoder
+	bodyBytes := r.body
 	if r.bodyEncoder != nil {
 		if len(r.body) > 0 {
-			return body, errorEncodedRawBodyCollision
+			return errorEncodedRawBodyCollision
 		}
 
-		r.body, err = r.bodyEncoder.Encode()
+		bodyBytes, err = r.bodyEncoder.Encode()
 		if err != nil {
-			return body, fmt.Errorf("error encoding body: %w", err)
+			return fmt.Errorf("error encoding body: %w", err)
 		}
+		req.Header.Set("Content-Type", r.bodyEncoder.ContentType())
 	}
 
-	if len(r.body) == 0 {
-		return http.NoBody, nil
-	}
+	contentLength := len(bodyBytes)
 
-	// If a delay was requested, assign a delayed reader
-	if r.delay > 0 {
-		return io.NopCloser(newDelayedReader(bytes.NewBuffer(r.body), r.delay)), nil
-	}
-
-	return io.NopCloser(bytes.NewBuffer(r.body)), nil
-}
-
-// RunWithContext executes a request using a specific context
-func (r *Request) RunWithContext(ctx context.Context) error {
-
-	reqBody, err := r.prepBody()
-	if err != nil {
-		return fmt.Errorf("error preparing request body: %w", err)
-	}
-
-	// Initialize new http.Request
-	//
 	// From net/http:
 	//
 	// 	If body is of type *bytes.Buffer, *bytes.Reader, or *strings.Reader, the returned request's ContentLength is set to its exact value
 	// 	(instead of -1), GetBody is populated (so 307 and 308 redirects can replay the body), and Body is set to NoBody if the ContentLength
 	// 	is 0.
-	req, err := http.NewRequestWithContext(ctx, r.method, r.uri, reqBody)
+	req.Body = http.NoBody
+	if contentLength > 0 {
+		req.ContentLength = int64(contentLength)
+
+		// If a delay was requested, assign a delayed reader
+		if r.delay > 0 {
+			dr := newDelayedReader(bytes.NewBuffer(bodyBytes), r.delay)
+
+			req.GetBody = func() (io.ReadCloser, error) {
+				snapshot := *dr
+				return io.NopCloser(&snapshot), nil
+			}
+			req.Body = io.NopCloser(dr)
+			return nil
+		}
+
+		buf := bytes.NewBuffer(bodyBytes)
+
+		req.GetBody = func() (io.ReadCloser, error) {
+			snapshot := *buf
+			return io.NopCloser(&snapshot), nil
+		}
+		req.Body = io.NopCloser(buf)
+	}
+
+	return nil
+}
+
+// RunWithContext executes a request using a specific context
+func (r *Request) RunWithContext(ctx context.Context) error {
+
+	// Initialize new http.Request
+
+	req, err := http.NewRequestWithContext(ctx, r.method, r.uri, nil)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
-	req.ContentLength = int64(len(r.body))
-	if req.GetBody == nil {
-		req.GetBody = func() (io.ReadCloser, error) {
-			return reqBody, nil
-		}
-	}
-
-	if r.bodyEncoder != nil {
-		req.Header.Set("Content-Type", r.bodyEncoder.ContentType())
+	err = r.setBody(req)
+	if err != nil {
+		return fmt.Errorf("failed to set request body: %w", err)
 	}
 
 	// Notify the server that the connection should be closed after completion of
@@ -460,7 +469,10 @@ func (r *Request) RunWithContext(ctx context.Context) error {
 		case <-ticker.C:
 		}
 
-		r.setBody(req)
+		err = r.setBody(req)
+		if err != nil {
+			return fmt.Errorf("failed to set request body: %w", err)
+		}
 		resp, err = r.client.Do(req)
 	}
 	if retryErrFn(resp, err) {
@@ -549,23 +561,6 @@ func (r *Request) setRetryHandling() (func(resp *http.Response, err error) bool,
 	}
 
 	return retryErrFn, nil
-}
-
-func (r *Request) setBody(req *http.Request) {
-	if len(r.body) > 0 {
-
-		// If a delay was requested, assign a delayed reader
-		if r.delay > 0 {
-			req.Body = io.NopCloser(newDelayedReader(bytes.NewBuffer(r.body), r.delay))
-		} else {
-			req.Body = io.NopCloser(bytes.NewBuffer(r.body))
-		}
-
-		// Pass content length to enforce non-chunked http request.
-		// Since data is completly in mem it's useless anyways.
-		// Also needed to mitigate a bug in PHP...
-		req.ContentLength = int64(len(r.body))
-	}
 }
 
 type delayReader struct {


### PR DESCRIPTION
Even though the tests were successful for the changes leading to `1.0.17`, the redirect would still not set the body correctly. I used an actual HTTP server as a test bed to verify this.

These changes work and are more or less copied from the `net/http` packages `NewRequestWithContext` function.

In the long run, we'll have to improve the test suite. It should have shown the error.